### PR TITLE
Ensure ChatSession serialization retains pin status

### DIFF
--- a/src/tedos/models/data_models.py
+++ b/src/tedos/models/data_models.py
@@ -70,15 +70,10 @@ class ChatSession:
 
     def to_dict(self) -> dict:
         """딕셔너리로 변환"""
-        return {
-            "id": self.id,
-            "title": self.title,
-            "messages": self.messages,
-            "created_at": self.created_at.isoformat(),
-            "updated_at": self.updated_at.isoformat(),
-            "metadata": self.metadata,
-            "is_pinned": self.is_pinned,
-        }
+        data = asdict(self)
+        data["created_at"] = self.created_at.isoformat()
+        data["updated_at"] = self.updated_at.isoformat()
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> "ChatSession":

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1,0 +1,40 @@
+import importlib.util
+import types
+from pathlib import Path
+from datetime import datetime
+import sys
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1] / "src"
+DM_PATH = ROOT / "tedos" / "models" / "data_models.py"
+
+sys.modules.setdefault("tedos", types.ModuleType("tedos"))
+sys.modules["tedos"].__path__ = [str(ROOT / "tedos")]
+sys.modules.setdefault("tedos.models", types.ModuleType("tedos.models"))
+sys.modules["tedos.models"].__path__ = [str(ROOT / "tedos" / "models")]
+
+spec = importlib.util.spec_from_file_location("tedos.models.data_models", DM_PATH)
+data_models = importlib.util.module_from_spec(spec)
+sys.modules["tedos.models.data_models"] = data_models
+spec.loader.exec_module(data_models)
+ChatSession = data_models.ChatSession
+
+
+def test_chat_session_is_pinned_roundtrip():
+    session = ChatSession(
+        id="123",
+        title="Test",
+        messages=[],
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        metadata={},
+        is_pinned=True,
+    )
+
+    data = session.to_dict()
+    assert data["is_pinned"] is True
+
+    recovered = ChatSession.from_dict(data)
+    assert recovered.is_pinned is True
+    assert recovered.id == session.id
+


### PR DESCRIPTION
## Summary
- include `is_pinned` when serializing `ChatSession`
- add unit test to verify pin state round‑trips through `to_dict`/`from_dict`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447fd9e0bc8322996c85d2e731524d