### PR TITLE
Add helper and data model unit tests

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,81 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+from datetime import datetime
+
+# Helper loader to import modules without executing heavy package __init__
+TEST_ROOT = Path(__file__).resolve().parents[1]
+TEDOS_PATH = TEST_ROOT / "src" / "tedos"
+
+if "tedos" not in sys.modules:
+    pkg = types.ModuleType("tedos")
+    pkg.__path__ = [str(TEDOS_PATH)]
+    sys.modules["tedos"] = pkg
+
+helpers = importlib.import_module("tedos.utils.helpers")
+models = importlib.import_module("tedos.models.data_models")
+
+
+def test_sanitize_filename_invalid_chars():
+    raw = 'test<>:"/\\|?*.txt'
+    assert helpers.sanitize_filename(raw) == 'test_________.txt'
+
+
+def test_sanitize_filename_whitespace_and_dots():
+    raw = '  bad .. file...name  '
+    assert helpers.sanitize_filename(raw) == 'bad . file.name'
+
+
+def test_truncate_text_noop():
+    text = 'hello'
+    assert helpers.truncate_text(text, max_length=10) == text
+
+
+def test_truncate_text_truncates():
+    text = 'hello world'
+    assert helpers.truncate_text(text, max_length=8) == 'hello...'
+
+
+def test_chat_session_serialization_roundtrip():
+    now = datetime.now()
+    original = models.ChatSession(
+        id='1',
+        title='t',
+        messages=[{"role": "user", "content": "hi"}],
+        created_at=now,
+        updated_at=now,
+        metadata={'a': 1},
+        is_pinned=True,
+    )
+    data = original.to_dict()
+    restored = models.ChatSession.from_dict(data)
+    assert restored == original
+
+
+def test_app_state_serialization_roundtrip():
+    now = datetime.now()
+    state = models.AppState(
+        current_session_id='s1',
+        current_page='chat',
+        is_initialized=True,
+        last_activity=now,
+    )
+    data = state.to_dict()
+    restored = models.AppState.from_dict(data)
+    assert restored == state
+
+
+def test_spotify_track_serialization_roundtrip():
+    track = models.SpotifyTrack(
+        id='t1',
+        name='Song',
+        artists='Artist',
+        duration_ms=210000,
+        album_name='Album',
+        release_date='2024-01-01',
+        popularity=50,
+    )
+    data = track.to_dict()
+    restored = models.SpotifyTrack.from_dict(data)
+    assert restored == track


### PR DESCRIPTION
## Summary
- add unit tests for sanitize_filename and truncate_text
- verify serialization of ChatSession, AppState and SpotifyTrack

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447fdbc8b48322936a6a2a81d0b800